### PR TITLE
Added guard name to backpack role seeder

### DIFF
--- a/database/seeds/RolesTableSeeder.php
+++ b/database/seeds/RolesTableSeeder.php
@@ -10,6 +10,9 @@ class RolesTableSeeder extends Seeder
      */
     public function run()
     {
-        Role::create(['name' => 'admin']);
+        Role::create([
+            'name' => 'admin',
+            'guard_name' => 'backpack',
+        ]);
     }
 }


### PR DESCRIPTION
Seeder should be working now, but users still need to remember to run it after migration.. that should still be addressed.