### PR TITLE
Fix vegan news widget height

### DIFF
--- a/resources/js/widgets/News.vue
+++ b/resources/js/widgets/News.vue
@@ -86,10 +86,6 @@ export default {
   min-width: 12rem;
 }
 
-.card {
-  height: 100%;
-}
-
 .card-img-top {
   height: 9.25rem;
   object-fit: cover;


### PR DESCRIPTION
Currently the vegan news widget has a height of 100% which causes the widget to show a large amount of empty space. This pull request fixes that. It's likely to do with the removal of the drag and drop functionality.