### PR TITLE
Feature/alt attribute for images

### DIFF
--- a/app/Widgets/DocOfTheMonth.php
+++ b/app/Widgets/DocOfTheMonth.php
@@ -19,15 +19,20 @@ class DocOfTheMonth extends AbstractWidget
 
     public function getData(): array
     {
-        return [
-            'imageUrl' => $this->getRandomDoc(),
-        ];
+        return $this->getRandomDoc();
     }
 
-    private function getRandomDoc(): string
+    private function getRandomDoc(): array
     {
-        $doc = File::files(public_path(self::DOC_DIR));
+        $docs = File::files(public_path(self::DOC_DIR));
+        $randDoc = $docs[array_rand($docs)];
+        $docFileName = $randDoc->getFileName();
+        $docName = pathinfo($docFileName, PATHINFO_FILENAME);
+        $imageUrl = self::DOC_DIR.'/'.$docFileName;
 
-        return self::DOC_DIR.'/'.$doc[array_rand($doc)]->getFilename();
+        return [
+            'imageUrl' => $imageUrl,
+            'docName' => $docName,
+        ];
     }
 }

--- a/resources/js/components/Slider.vue
+++ b/resources/js/components/Slider.vue
@@ -10,7 +10,7 @@
               target="_blank"
               rel="noopener"
             >
-              <img class="card-img-top" :src="item.featuredImage" />
+              <img class="card-img-top" :src="item.featuredImage" alt="" />
             </a>
             <video
               v-else

--- a/resources/js/widgets/Art.vue
+++ b/resources/js/widgets/Art.vue
@@ -2,7 +2,7 @@
   <Widget :name="name" :error="data.error">
     <figure>
       <a :href="data.imageUrl" target="_blank" rel="noopener">
-        <img class="image" :src="data.imageUrl" v-bind:alt="data.imageAlt" />
+        <img class="image" :src="data.imageUrl" :alt="imageAlt" />
       </a>
       <figcaption v-if="data.caption">— {{ data.caption }}</figcaption>
     </figure>
@@ -31,6 +31,10 @@
       Widget,
     },
     computed: {
+      imageAlt() {
+        const { imageAlt } = this.data;
+        return imageAlt ? imageAlt : "";
+      },
       shareTitle() {
         const { origin } = document.location
         return `${origin}/${this.data.imageUrl} - find more vegan art at ${origin}!`

--- a/resources/js/widgets/DeathCounter.vue
+++ b/resources/js/widgets/DeathCounter.vue
@@ -6,7 +6,7 @@
           <li class="list-group-item px-0 border-0">
             <img
               :src="animal.icon"
-              :alt="animal.name + ' icon'"
+              :alt="animal.name"
               :title="animal.name"
             />
             {{ Math.ceil(animal.value).toLocaleString() }}

--- a/resources/js/widgets/DocOfTheMonth.vue
+++ b/resources/js/widgets/DocOfTheMonth.vue
@@ -2,7 +2,7 @@
   <Widget :name="name" :error="data.error">
     <figure>
       <a href="http://3movies.org/" target="_blank" rel="noopener">
-        <img class="image" :src="data.imageUrl" :alt="docName" />
+        <img class="image" :src="data.imageUrl" :alt="imageAlt" />
       </a>
     </figure>
     <ShareUs :buttonText="'Doc of the month'" :title="shareTitle" />
@@ -30,7 +30,7 @@
       Widget,
     },
     computed: {
-      docName() {
+      imageAlt() {
         const { docName } = this.data;
         return docName.charAt(0).toUpperCase() + docName.slice(1);
       },

--- a/resources/js/widgets/DocOfTheMonth.vue
+++ b/resources/js/widgets/DocOfTheMonth.vue
@@ -2,7 +2,7 @@
   <Widget :name="name" :error="data.error">
     <figure>
       <a href="http://3movies.org/" target="_blank" rel="noopener">
-        <img class="image" :src="data.imageUrl" />
+        <img class="image" :src="data.imageUrl" :alt="docName" />
       </a>
     </figure>
     <ShareUs :buttonText="'Doc of the month'" :title="shareTitle" />
@@ -30,6 +30,10 @@
       Widget,
     },
     computed: {
+      docName() {
+        const { docName } = this.data;
+        return docName.charAt(0).toUpperCase() + docName.slice(1);
+      },
       shareTitle() {
         const { origin } = document.location
         return `${origin}/${this.data.imageUrl} - find more vegan documentaries at ${origin}!`

--- a/resources/js/widgets/MemeOfTheDay.vue
+++ b/resources/js/widgets/MemeOfTheDay.vue
@@ -2,7 +2,7 @@
   <Widget :name="name" :error="data.error">
     <figure>
       <a :href="data.imageUrl" target="_blank">
-        <img class="image" :src="data.imageUrl" />
+        <img class="image" :src="data.imageUrl" :alt="imageAlt" />
       </a>
     </figure>
     <ShareUs :buttonText="name" :title="shareTitle" />
@@ -30,6 +30,10 @@
       Widget,
     },
     computed: {
+      imageAlt() {
+        const { imageAlt } = this.data;
+        return imageAlt ? imageAlt : "";
+      },
       shareTitle() {
         const { origin } = document.location
         return `${origin}/${this.data.imageUrl} - find more vegan memes at ${origin}!`

--- a/resources/js/widgets/VeganBootcamp.vue
+++ b/resources/js/widgets/VeganBootcamp.vue
@@ -2,7 +2,7 @@
   <Widget :name="name" :error="data.error">
     <figure>
       <a href="http://vbcamp.org/dailynooch" target="_blank">
-        <img class="image" :src="data.imageUrl" />
+        <img class="image" :src="data.imageUrl" alt="Vegan Bootcamp – Take the Vegan 30 Day Challenge" />
       </a>
     </figure>
     <p>


### PR DESCRIPTION
https://trello.com/c/A9qcUsif/48-alt-attribute-for-images

- Adds an `alt` attribute to Meme of the Day, Art of the Day images that can be provided from BE
- Adds an empty `alt` attribute to image of Slider component (implemented by news, r/Vegan, recipes, etc.)
- Remove `"icon"` string from ends of animal icons in Death Counter
- Adds name of documentary to `alt` attribute of documentary image
- Add `alt` attribute to Vegan Bootcamp image